### PR TITLE
複数カードの登録を可能にした

### DIFF
--- a/go/app/apifuncs/UserCard.go
+++ b/go/app/apifuncs/UserCard.go
@@ -1,0 +1,60 @@
+package apifuncs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"set1.ie.aitech.ac.jp/room_management/dbctl"
+)
+
+type recUserCardData struct {
+	UID   string `json:"uid"`
+	Email string `json:"email"`
+}
+
+//UserCardResponce is UserCardResponce
+func UserCardResponce(w http.ResponseWriter, r *http.Request) {
+	//セキュリティ設定
+	w.Header().Set("Access-Control-Allow-Origin", "*")                       // Allow any access.
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE") // Allowed methods.
+	w.Header().Set("Access-Control-Allow-Headers", "*")
+
+	r.Header.Set("Content-Type", "application/json")
+	if r.Method == http.MethodPost {
+		jsonBytes, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprintln(w, `{"status":"Unavailable"}`)
+			fmt.Println("Can't catch data(io error)", err)
+			return
+		}
+
+		var rec recUserCardData
+
+		if err := json.Unmarshal(jsonBytes, &rec); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprintln(w, `{"status":"Unavailable"}`)
+			fmt.Println("Can't catch data(JSON Unmarshal error)", err)
+			return
+		}
+
+		if err := dbctl.LinkUserAndCard(rec.UID, rec.Email); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprintln(w, `{"status":"Unavailable"}`)
+			fmt.Println("database error(LinkUserAndCard)", err)
+			return
+		}
+
+		if err := dbctl.OrganizeLog(rec.UID, rec.Email); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprintln(w, `{"status":"Unavailable"}`)
+			fmt.Println("database error(OrganizeLog)", err)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, `{"status":"available"}`)
+	}
+}

--- a/go/app/dbctl/userCard.go
+++ b/go/app/dbctl/userCard.go
@@ -78,7 +78,7 @@ func OrganizeLog(uid string, email string) error {
 		nextValue = 1 - isEntry.Int64
 	}
 
-	_, err = db.Exec("update logs inner join (select id, @row:=@row+1 RowNum from (select logs.id from logs inner join cards on logs.cards_id = cards.id where card_read_datetime >= ? and user_id = ? order by card_read_datetime asc) l, (select @row:=0) r) t on logs.id = t.id set isEntry = case when RowNum%2=1 then ? else ? end", oldCardReadDatetime, userID, nextValue, 1-nextValue)
+	_, err = db.Exec("update logs inner join (select id, row_number() over (order by id asc) RowNum from (select logs.id from logs inner join cards on logs.cards_id = cards.id where card_read_datetime >= ? and user_id = ? order by card_read_datetime asc) l) t on logs.id = t.id set isEntry = case when RowNum%2=1 then ? else ? end", oldCardReadDatetime, userID, nextValue, 1-nextValue)
 	if err != nil {
 		pc, file, line, _ := runtime.Caller(0)
 		f := runtime.FuncForPC(pc)

--- a/go/app/dbctl/userCard.go
+++ b/go/app/dbctl/userCard.go
@@ -1,0 +1,132 @@
+package dbctl
+
+import (
+	"database/sql"
+	"errors"
+	"log"
+	"runtime"
+)
+
+//LinkUserAndCard はユーザとカードをリンクさせる関数
+func LinkUserAndCard(uid string, email string) error {
+	//カードに既にユーザが登録されていないか確認する
+	if err := checkLinkedUserAndCard(uid, email); err != nil {
+		return err
+	}
+
+	//update
+	res, err := db.Exec("update cards set user_id = (select users.id from users, emails where users.email_id = emails.id and email = ?) where uid = ?", email, uid)
+	if err != nil {
+		pc, file, line, _ := runtime.Caller(0)
+		f := runtime.FuncForPC(pc)
+		log.Printf(errFormat, err, f.Name(), file, line)
+		return err
+	}
+
+	//updateによって影響を受けた行の数を取得
+	var affectedRows int64
+	if affectedRows, err = res.RowsAffected(); err != nil {
+		pc, file, line, _ := runtime.Caller(0)
+		f := runtime.FuncForPC(pc)
+		log.Printf(errFormat, err, f.Name(), file, line)
+		return err
+	}
+
+	//更新時にエラーが発生しなかったが、紐付けできなかった場合。
+	if affectedRows == 0 {
+		log.Printf("ERROR: Linkage failure")
+		log.Printf("It's possible that the email or uid did not exist.")
+		log.Printf("Please check the uid and email you entered.")
+		return errors.New("ERROR: Linkage failure")
+	}
+
+	return nil
+}
+
+//OrganizeLog はLogの矛盾を解消する関数
+func OrganizeLog(uid string, email string) error {
+	//LinkUserAndCardで紐付けしたカードの最も古い読み取り時間を取得
+	rows, err := db.Query("select card_read_datetime, user_id from logs, cards where logs.cards_id = cards.id and uid=? order by card_read_datetime asc limit 1", uid)
+	if err != nil {
+		pc, file, line, _ := runtime.Caller(0)
+		f := runtime.FuncForPC(pc)
+		log.Printf(errFormat, err, f.Name(), file, line)
+		return err
+	}
+	defer rows.Close()
+
+	var oldCardReadDatetime string
+	var userID string
+	rows.Next()
+	rows.Scan(&oldCardReadDatetime, &userID)
+
+	//ユーザの紐付けしたカードを初めて使う直前の入退室情報を取得
+	rows, err = db.Query("select isEntry from logs, cards where logs.cards_id = cards.id and card_read_datetime < ? and user_id = ? order by card_read_datetime desc", oldCardReadDatetime, userID)
+	if err != nil {
+		pc, file, line, _ := runtime.Caller(0)
+		f := runtime.FuncForPC(pc)
+		log.Printf(errFormat, err, f.Name(), file, line)
+		return err
+	}
+	var isEntry sql.NullInt64 = sql.NullInt64{}
+	var nextValue int64
+	rows.Next()
+	rows.Scan(&isEntry)
+	if !isEntry.Valid {
+		nextValue = 1
+	} else {
+		nextValue = 1 - isEntry.Int64
+	}
+
+	_, err = db.Exec("update logs inner join (select id, @row:=@row+1 RowNum from (select logs.id from logs inner join cards on logs.cards_id = cards.id where card_read_datetime >= ? and user_id = ? order by card_read_datetime asc) l, (select @row:=0) r) t on logs.id = t.id set isEntry = case when RowNum%2=1 then ? else ? end", oldCardReadDatetime, userID, nextValue, 1-nextValue)
+	if err != nil {
+		pc, file, line, _ := runtime.Caller(0)
+		f := runtime.FuncForPC(pc)
+		log.Printf(errFormat, err, f.Name(), file, line)
+		return err
+	}
+
+	if err := syncIsEntry(userID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//checkLinkedUserAndCard is カードに既にユーザが登録されているか確認する関数
+//登録されていた場合、エラーになる。
+func checkLinkedUserAndCard(uid string, email string) error {
+	rows, err := db.Query("select user_id from cards where uid = ?", uid)
+	if err != nil {
+		pc, file, line, _ := runtime.Caller(0)
+		f := runtime.FuncForPC(pc)
+		log.Printf(errFormat, err, f.Name(), file, line)
+		return err
+	}
+	defer rows.Close()
+
+	var userID sql.NullString = sql.NullString{}
+	rows.Next()
+	rows.Scan(&userID)
+	if userID.Valid {
+		log.Printf("ERROR: Already registered user")
+		log.Printf("A user is already registered on the card.")
+		log.Printf("Please check uid.")
+		return errors.New("ERROR: Already registered user")
+	}
+
+	return nil
+}
+
+//syncIsEntry is usersのisEntryを更新する関数
+func syncIsEntry(userID string) error {
+	_, err := db.Exec("update users set isEntry = (select isEntry from logs where exists (select * from cards where logs.cards_id = cards.id and users.id = ?) order by card_read_datetime desc limit 1) where id = ?", userID, userID)
+	if err != nil {
+		pc, file, line, _ := runtime.Caller(0)
+		f := runtime.FuncForPC(pc)
+		log.Printf(errFormat, err, f.Name(), file, line)
+		return err
+	}
+
+	return nil
+}

--- a/go/app/main.go
+++ b/go/app/main.go
@@ -12,6 +12,7 @@ func main() {
 	log.Print("hello world\n")
 	http.HandleFunc("/card", apifuncs.CardResponse)
 	http.HandleFunc("/user", apifuncs.UserResponse)
+	http.HandleFunc("/user/card", apifuncs.UserCardResponce)
 	http.HandleFunc("/log", apifuncs.LogResponse)
 	http.ListenAndServe(":80", nil)
 }


### PR DESCRIPTION
動作としては、/cardに
'1 2 3 4'
'1 1 1 1'
'1 2 3 4'
'1 1 1 1'
という順番でpostを送信した場合、両方のカードが同じユーザでないのであればlogsのisEntryは古いlogから
1
1
0
0
という様になりますが、/user/cardにuidとemailをjsonで送信して両方のカードを同じユーザの物として登録すると
1
0
1
0
という様にisEntryを更新します。
cards_idは別々でも、同じユーザのカードであった場合、入室と退室が交互になる様に実装したということになります。

補足
LinkUserAndCardは、cardsのuser_idを更新し、userと紐付けを行う関数です。一応、
・既に紐付けされたカードを指定された場合
・email、もしくはuidがデータベース内に存在しなかった場合
の2点はエラーとして処理しています。

OrganizeLogはカードが紐付けされた後、同じユーザのisEntryが交互になるようにisEntryを更新する関数です。
まず、紐付けしたカードの一番最初の読み取った時間（とついでにuserID）を取得します。
その情報を用いて、紐付けしたカードを初めて使った時の一つ前のisEntryを取得します。このカードがユーザが初めて当システムを使用する際に使用したカードだった場合、この演算の結果はnullとなるため、代わりに1が取得されます。（初めてタッチする時とは即ち入室する時であるため。）
以上の情報から、同じユーザの、交互に直さなければいけない時間（つまり、初めて紐付けされたカードを使用した時以降）のisEntryを全て交互に直します。
最後に、一番最新のユーザの入退室情報をlogsから取得し、その情報でusersのisEntryを更新しています。

checkLinkedUserAndCardとsyncIsEntryは、それぞれカードに既にユーザが登録されていないか確認する関数とusersのisEntryを同期する関数です。一連の処理の流れの中で、違う要素の処理をするので、関数を分けました。

以上