### PR TITLE
APIでログを取得したときに，最新のものが先頭に来るように変更しました

### DIFF
--- a/go/app/dbctl/log.go
+++ b/go/app/dbctl/log.go
@@ -17,7 +17,7 @@ type LogInfo struct {
 
 //GetLogInfos can get log no info
 func GetLogInfos() ([]LogInfo, error) {
-	rows, err := db.Query("select logs.id, student_number, name, card_read_datetime, uid, logs.isEntry from logs, cards left outer join users on users.id=cards.user_id where logs.cards_id=cards.id order by card_read_datetime")
+	rows, err := db.Query("select logs.id, student_number, name, card_read_datetime, uid, logs.isEntry from logs, cards left outer join users on users.id=cards.user_id where logs.cards_id=cards.id order by card_read_datetime desc")
 	if err != nil {
 		pc, file, line, _ := runtime.Caller(0)
 		f := runtime.FuncForPC(pc)


### PR DESCRIPTION
SQL文が `order by card_read_datetime` で終わっていたので `order by card_read_datetime desc` に変更しました．
これによって，最新のログが先頭に来るようになります．現に，vue側で逆順にソートするようにはしていないので，API側から逆順で送ってあげたほうが見やすくなると思います．
書き忘れかな？とも思ったけど，何か理由があるなら無視してください．