### PR TITLE
add:Resetの実装

### DIFF
--- a/go/app/apifuncs/Log.go
+++ b/go/app/apifuncs/Log.go
@@ -22,6 +22,11 @@ func LogResponse(w http.ResponseWriter, r *http.Request) {
 		var logInfos []dbctl.LogInfo
 
 		logInfos, err := dbctl.GetLogInfos()
+		if err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			log.Fatal(err)
+			return
+		}
 
 		jsonBytes, err := json.Marshal(logInfos)
 		if err != nil {

--- a/go/app/apifuncs/Week.go
+++ b/go/app/apifuncs/Week.go
@@ -1,0 +1,112 @@
+package apifuncs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"set1.ie.aitech.ac.jp/room_management/dbctl"
+)
+
+type recWeekPut struct {
+	Email string `json:"email"`
+	Day   string `json:"day"`
+}
+
+//WeekResponce is a function with regards to /week.
+func WeekResponce(w http.ResponseWriter, r *http.Request) {
+	//セキュリティ設定
+	w.Header().Set("Access-Control-Allow-Origin", "*")                       // Allow any access.
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE") // Allowed methods.
+	w.Header().Set("Access-Control-Allow-Headers", "*")
+
+	if r.Method == http.MethodGet {
+
+		var resetSettings []dbctl.ResetSettingData
+
+		resetSettings, err := dbctl.GetResetSettings()
+
+		jsonBytes, err := json.Marshal(resetSettings)
+		if err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			log.Fatal(err)
+			return
+		}
+
+		jsonString := string(jsonBytes)
+
+		w.WriteHeader(http.StatusOK)
+		r.Header.Set("Content-Type", "application/json")
+
+		if resetSettings == nil {
+			jsonString = "[]"
+		}
+
+		fmt.Fprintln(w, jsonString)
+
+	} else if r.Method == http.MethodPost {
+
+		jsonBytes, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprintln(w, `{"status":"Unavailable"}`)
+			fmt.Println("Can't catch Setting Data(io error)", err)
+			return
+		}
+
+		var rec dbctl.ResetSettingData
+
+		if err := json.Unmarshal(jsonBytes, &rec); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprintln(w, `{"status":"Unavailable"}`)
+			fmt.Println("Can't catch Setting Data(JSON Unmarshal error)", err)
+			return
+		}
+
+		if err := dbctl.InsertResetSetting(rec.Email, rec.Day, rec.IsOnce); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprintln(w, `{"status":"Unavailable"}`)
+			fmt.Println("database error(InsertResetSetting)", err)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, `{"status":"available"}`)
+
+	} else if r.Method == http.MethodPut {
+
+		jsonBytes, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprintln(w, `{"status":"Unavailable"}`)
+			fmt.Println("Can't catch Setting Data(io error)", err)
+			return
+		}
+
+		var rec recWeekPut
+
+		if err := json.Unmarshal(jsonBytes, &rec); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprintln(w, `{"status":"Unavailable"}`)
+			fmt.Println("Can't catch Setting Data(JSON Unmarshal error)", err)
+			return
+		}
+
+		if err := dbctl.DeleteResetSetting(rec.Email, rec.Day); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprintln(w, `{"status":"Unavailable"}`)
+			fmt.Println("database error(DeleteResetSetting)", err)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, `{"status":"available"}`)
+	}
+}
+
+//ResetEntryFlagTest debugs ResetEntryFlag.
+func ResetEntryFlagTest(w http.ResponseWriter, r *http.Request) {
+	dbctl.ResetEntryFlag()
+}

--- a/go/app/apifuncs/Week.go
+++ b/go/app/apifuncs/Week.go
@@ -17,11 +17,17 @@ func WeekResponce(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE") // Allowed methods.
 	w.Header().Set("Access-Control-Allow-Headers", "*")
 
+	r.Header.Set("Content-Type", "application/json")
 	if r.Method == http.MethodGet {
 
 		var resetSettings []dbctl.ResetSettingData
 
 		resetSettings, err := dbctl.GetResetSettings()
+		if err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			log.Fatal(err)
+			return
+		}
 
 		jsonBytes, err := json.Marshal(resetSettings)
 		if err != nil {
@@ -33,7 +39,6 @@ func WeekResponce(w http.ResponseWriter, r *http.Request) {
 		jsonString := string(jsonBytes)
 
 		w.WriteHeader(http.StatusOK)
-		r.Header.Set("Content-Type", "application/json")
 
 		if resetSettings == nil {
 			jsonString = "[]"

--- a/go/app/apifuncs/Week.go
+++ b/go/app/apifuncs/Week.go
@@ -10,11 +10,6 @@ import (
 	"set1.ie.aitech.ac.jp/room_management/dbctl"
 )
 
-type recWeekPut struct {
-	Email string `json:"email"`
-	Day   string `json:"day"`
-}
-
 //WeekResponce is a function with regards to /week.
 func WeekResponce(w http.ResponseWriter, r *http.Request) {
 	//セキュリティ設定
@@ -85,7 +80,7 @@ func WeekResponce(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		var rec recWeekPut
+		var rec dbctl.ResetSettingData
 
 		if err := json.Unmarshal(jsonBytes, &rec); err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
@@ -94,7 +89,7 @@ func WeekResponce(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if err := dbctl.DeleteResetSetting(rec.Email, rec.Day); err != nil {
+		if err := dbctl.DeleteResetSetting(rec.Email, rec.Day, rec.IsOnce); err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			fmt.Fprintln(w, `{"status":"Unavailable"}`)
 			fmt.Println("database error(DeleteResetSetting)", err)

--- a/go/app/dbctl/week.go
+++ b/go/app/dbctl/week.go
@@ -1,0 +1,117 @@
+package dbctl
+
+import (
+	"log"
+	"runtime"
+	"time"
+)
+
+//ResetSettingData is one struct in a reset setting.
+type ResetSettingData struct {
+	Email  string `json:"email"`
+	Day    string `json:"day"`
+	IsOnce bool   `json:"isOnce"`
+}
+
+//GetResetSettings is a function to get list of resetSettings.
+func GetResetSettings() ([]ResetSettingData, error) {
+	var resetSettingDatas []ResetSettingData
+	rows, err := db.Query("select day, isOnce, email from week, users, emails where week.users_id = users.id and users.email_id = emails.id")
+	if err != nil {
+		pc, file, line, _ := runtime.Caller(0)
+		f := runtime.FuncForPC(pc)
+		log.Printf(errFormat, err, f.Name(), file, line)
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var day string
+		var isOnce int
+		var email string
+		rows.Scan(&day, &isOnce, &email)
+
+		var isOnceBool bool
+		if isOnce == 0 {
+			isOnceBool = false
+		} else {
+			isOnceBool = true
+		}
+
+		resetSettingDatas = append(resetSettingDatas, ResetSettingData{Email: email, Day: day, IsOnce: isOnceBool})
+	}
+
+	return resetSettingDatas, nil
+}
+
+//InsertResetSetting is a function to add a resetSetting to Week.
+func InsertResetSetting(email string, day string, isOnce bool) error {
+	var isOnceInt int
+	if isOnce {
+		isOnceInt = 1
+	} else {
+		isOnceInt = 0
+	}
+	_, err := db.Exec("insert into week(day, isOnce, users_id) select ?, ?, id from users where exists (select * from emails where emails.id = users.email_id and email = ?)", day, isOnceInt, email)
+	if err != nil {
+		pc, file, line, _ := runtime.Caller(0)
+		f := runtime.FuncForPC(pc)
+		log.Printf(errFormat, err, f.Name(), file, line)
+		return err
+	}
+
+	return nil
+}
+
+//DeleteResetSetting is a function to delete a resetSetting from Week.
+func DeleteResetSetting(email string, day string) error {
+	_, err := db.Exec("delete from week where day = ? and users_id in (select users.id from users, emails where users.email_id = emails.id and email = ?)", day, email)
+	if err != nil {
+		pc, file, line, _ := runtime.Caller(0)
+		f := runtime.FuncForPC(pc)
+		log.Printf(errFormat, err, f.Name(), file, line)
+		return err
+	}
+
+	return nil
+}
+
+//ResetEntryFlag do reset.
+func ResetEntryFlag() error {
+	wdays := []string{"sun", "mon", "tue", "wed", "thu", "fri", "sat"}
+	day := wdays[(time.Now().Weekday()+6)%7]
+
+	_, err := db.Exec("insert into logs(cards_id, card_read_datetime, isEntry) select min(cards.id), Now(), 0 from users, cards where users.id = cards.user_id and isEntry = 1 and not exists (select * from week where users.id = week.users_id and week.day = ?) group by users.id", day)
+	if err != nil {
+		pc, file, line, _ := runtime.Caller(0)
+		f := runtime.FuncForPC(pc)
+		log.Printf(errFormat, err, f.Name(), file, line)
+		return err
+	}
+
+	_, err = db.Exec("update users set isEntry = 0 where isEntry = 1 and not exists (select * from week where users.id = week.users_id and week.day = ?)", day)
+	if err != nil {
+		pc, file, line, _ := runtime.Caller(0)
+		f := runtime.FuncForPC(pc)
+		log.Printf(errFormat, err, f.Name(), file, line)
+		return err
+	}
+
+	if err = deleteOnceResetSetting(day); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deleteOnceResetSetting(day string) error {
+	_, err := db.Exec("delete from week where isOnce = 1 and day = ?", day)
+	if err != nil {
+		pc, file, line, _ := runtime.Caller(0)
+		f := runtime.FuncForPC(pc)
+		log.Printf(errFormat, err, f.Name(), file, line)
+		return err
+	}
+
+	return nil
+}

--- a/go/app/dbctl/week.go
+++ b/go/app/dbctl/week.go
@@ -64,8 +64,14 @@ func InsertResetSetting(email string, day string, isOnce bool) error {
 }
 
 //DeleteResetSetting is a function to delete a resetSetting from Week.
-func DeleteResetSetting(email string, day string) error {
-	_, err := db.Exec("delete from week where day = ? and users_id in (select users.id from users, emails where users.email_id = emails.id and email = ?)", day, email)
+func DeleteResetSetting(email string, day string, isOnce bool) error {
+	var isOnceInt int
+	if isOnce {
+		isOnceInt = 1
+	} else {
+		isOnceInt = 0
+	}
+	_, err := db.Exec("delete from week where day = ? and isOnce = ? and users_id in (select users.id from users, emails where users.email_id = emails.id and email = ?)", day, isOnceInt, email)
 	if err != nil {
 		pc, file, line, _ := runtime.Caller(0)
 		f := runtime.FuncForPC(pc)

--- a/go/app/main.go
+++ b/go/app/main.go
@@ -14,5 +14,7 @@ func main() {
 	http.HandleFunc("/user", apifuncs.UserResponse)
 	http.HandleFunc("/user/card", apifuncs.UserCardResponce)
 	http.HandleFunc("/log", apifuncs.LogResponse)
+	http.HandleFunc("/reset", apifuncs.WeekResponce)
+	// http.HandleFunc("/resetTest", apifuncs.ResetEntryFlagTest)
 	http.ListenAndServe(":80", nil)
 }


### PR DESCRIPTION
補足

リセット設定の現在の取得は、リセットしない設定の数が要素数の、Email,Day,IsOnceから成る配列を返します。フロント側でうまく整形しないと若干使いにくいです。（変更を加えてある程度バックエンドでデータの形を綺麗に整えて送ることは可能）

リセット設定のpostは、Email,Day,IsOnceを送ることで使用することができます。つまり、設定を変更したい数だけpostを送信しなければなりません（効率が悪い）

あと、まだフロントでガバを起こして謎のデータが送られてきた時の対策ができていない。